### PR TITLE
Fix subcategory deletion and dynamic DB URL configuration

### DIFF
--- a/src/knowledge_base/config.py
+++ b/src/knowledge_base/config.py
@@ -7,7 +7,13 @@ class SettingsApp(BaseSettings):
     DB_USER: str = "user"
     DB_PASSWORD: str = "password"
     DB_PORT: int = 5432
-    DB_URL: str = f"postgresql+asyncpg://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+
+    @property
+    def DB_URL(self) -> str:
+        return (
+            f"postgresql+asyncpg://{self.DB_USER}:{self.DB_PASSWORD}"
+            f"@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
+        )
 
 
 def get_settings_app() -> SettingsApp:

--- a/src/knowledge_base/domain/services/subcategory_policy.py
+++ b/src/knowledge_base/domain/services/subcategory_policy.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from knowledge_base.domain.repository.question_repository import QuestionRepository
 from knowledge_base.domain.repository.source_repository import SourceRepository
 from knowledge_base.domain.repository.task_repository import TaskRepository
@@ -11,8 +13,10 @@ class SubCategoryDeletionPolicy:
         self.question: QuestionRepository = question
 
     async def can_delete(self, id_subcategory: Id) -> bool:
-        return not (
-            await self.task.exists_by_subcategory(id_subcategory)
-            and await self.source.exists_by_subcategory(id_subcategory)
-            and await self.question.exists_by_subcategory(id_subcategory)
+        task_exists, source_exists, question_exists = await asyncio.gather(
+            self.task.exists_by_subcategory(id_subcategory),
+            self.source.exists_by_subcategory(id_subcategory),
+            self.question.exists_by_subcategory(id_subcategory),
         )
+
+        return not any((task_exists, source_exists, question_exists))


### PR DESCRIPTION
## Summary
- correct subcategory deletion policy to block removal if any related data exists
- check existence across repositories concurrently for faster lookups
- compute DB_URL from runtime settings so config respects environment overrides

## Testing
- `poetry run ruff check`
- `poetry run mypy src`


------
https://chatgpt.com/codex/tasks/task_e_689a3d8901ac83268442f76fd2007f8f